### PR TITLE
Add support for transparent PNGs

### DIFF
--- a/CBLutGen.cpp
+++ b/CBLutGen.cpp
@@ -138,10 +138,11 @@ namespace
         for (int i = 0; i < n; i++)
         {
             Vec3f c = FromRGBA32(dataIn[i]);
+            uint8_t alpha = dataIn[i].c[3];
 
             c = xform(c);
 
-            dataOut[i] = ToRGBA32(c);
+            dataOut[i] = ToRGBA32(c, alpha);
         }
     }
 
@@ -556,7 +557,7 @@ int main(int argc, const char* argv[])
                         assert(rgb.y >= 0.0f && rgb.y <= 1.0f);
                         assert(rgb.z >= 0.0f && rgb.z <= 1.0f);
                         
-                        RGBA32 c = ToRGBA32(rgb);
+                        RGBA32 c = ToRGBA32(rgb, 255);
 
                         (*p++) = c;
                     }

--- a/CBLuts.cpp
+++ b/CBLuts.cpp
@@ -427,7 +427,7 @@ void CBLut::ApplyLUT(RGBA32 rgbLUT[kLUTSize][kLUTSize][kLUTSize], int n, const R
         dataOut[i].c[0] = ch0;
         dataOut[i].c[1] = ch1;
         dataOut[i].c[2] = ch2;
-        dataOut[i].c[3] = 255;
+        dataOut[i].c[3] = dataIn[i].c[3];
     }
 }
 

--- a/CBLuts.cpp
+++ b/CBLuts.cpp
@@ -307,7 +307,7 @@ namespace
     }
 }
 
-RGBA32 CBLut::ToRGBA32(Vec3f c)
+RGBA32 CBLut::ToRGBA32(Vec3f c, uint8_t alpha)
 {
     c = pow(c, 1.0f / kGamma);
     RGBA32 result;
@@ -315,7 +315,7 @@ RGBA32 CBLut::ToRGBA32(Vec3f c)
     result.c[0] = ToU8(c.x);
     result.c[1] = ToU8(c.y);
     result.c[2] = ToU8(c.z);
-    result.c[3] = 255;
+    result.c[3] = alpha;
 
     return result;
 }

--- a/CBLuts.h
+++ b/CBLuts.h
@@ -48,7 +48,7 @@ namespace CBLut
         };
     };
     
-    RGBA32 ToRGBA32   (Vec3f c);
+    RGBA32 ToRGBA32   (Vec3f c, uint8_t alpha);
     RGBA32 ToRGBA32u  (Vec3f c);
     Vec3f  FromRGBA32 (RGBA32 rgb);
     Vec3f  FromRGBA32u(RGBA32 rgb);


### PR DESCRIPTION
Transparency shouldn't be affected by colour transformation, so when building the output data I copy over the input alpha value instead of setting it to 255.

Testing was done on a couple of transparent PNGs on my hard drive, and a non-regression test was ran using the provided images.